### PR TITLE
center info-content

### DIFF
--- a/democracy/page/default_home/css/default_home.css
+++ b/democracy/page/default_home/css/default_home.css
@@ -48,7 +48,7 @@
         margin: 150px auto 0;
     }
 }
-  
+
 .scroll-icon-container {
     font-size: 20px;
     position: absolute;
@@ -109,7 +109,7 @@
 }
 
 .header .container {
-    
+
 }
 .header-content-inner{
     color: #fff;
@@ -158,6 +158,7 @@
 }
 .info-content {
     padding-top: 35px;
+    padding-bottom: 35px;
     padding-left: 5px;
     padding-right: 25px;
     font-size: 20px;


### PR DESCRIPTION
This commit fixes the uneven paddings in Mozilla Firefox concerning the "info-content" css-class: 



Before: 
![image](https://user-images.githubusercontent.com/24357433/84280697-ef073780-ab37-11ea-8f50-9056878fe145.png)

After: 
![image](https://user-images.githubusercontent.com/24357433/84281286-b1ef7500-ab38-11ea-945f-d03dc3052bf2.png)
